### PR TITLE
Version 1.2.0 - HTML Messages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,24 @@
+# Change Log
+
+## Version 1.2.0
+Added HTML capabilities within MouseTip messages!
+- By default, MouseTip runs with HTML capabilities turned off.
+- HTML capabilities can be enabled globally via `html: true` in the global settings object
+- HTML capabilities can be enabled/disabled individually via the `mousetip-enable-html` or `mousetip-disable-html` attribute
+
+## Version 1.1.0
+Added new MouseTip constructor setting **selector**
+- Now you can namespace every MouseTip instance
+- When a custom selector is passed into the settings, MouseTip will look for attributes with that new namespace (i.e. "awesomeName" instead of "mousetip", "awesomeName-css-zindex" instead of "mousetip-css-zindex")
+- Check out the *How to Use* section in readme.md to see this new setting in action
+
+## Version 1.0.1
+Simple bug fixes:
+- Updated the bindMouseMove function to utilize pageX/pageY instead of clientX/clientY
+- Fixed missing-semicolon JSHint warnings in the mousetip script
+
+## Version 1.0.0
+Version 1.0.0 is here, and it includes an entirely new way to use the PureJS MouseTip script!
+- The script is now wrapped in a MouseTip constructor function instead of a self-executing function
+- The script can now take global style/position overrides when an instance of the constructor is created
+- The script will not find the MouseTip elements or bind mouse events until a constructor instance's .run() function is called

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purejs-mousetip",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A pure javascript solution for creating tooltips that follow your mouse",
   "main": "gulpfile.js",
   "repository": {

--- a/readme.md
+++ b/readme.md
@@ -3,23 +3,13 @@ A pure javascript solution for creating tooltips that follow your mouse. This pr
 
 ![A demonstration of the javascript in action](http://joeleisner.com/github/screenshots/purejs-mousetip/purejs-moustip-demo.gif)
 
-## Change Log
-### Version 1.1.0
-Added new MouseTip constructor setting **selector**
-- Now you can namespace every MouseTip instance
-- When a custom selector is passed into the settings, MouseTip will look for attributes with that new namespace (i.e. "awesomeName" instead of "mousetip", "awesomeName-css-zindex" instead of "mousetip-css-zindex")
-- Check out the *How to Use* section to see this new setting in action
+## Version 1.2.0
+Added HTML capabilities within MouseTip messages!
+- By default, MouseTip runs with HTML capabilities turned off.
+- HTML capabilities can be enabled globally via `html: true` in the global settings object
+- HTML capabilities can be enabled/disabled individually via the `mousetip-enable-html` or `mousetip-disable-html` attribute
 
-### Version 1.0.1
-Simple bug fixes:
-- Updated the bindMouseMove function to utilize pageX/pageY instead of clientX/clientY
-- Fixed missing-semicolon JSHint warnings in the mousetip script
-
-### Version 1.0.0
-Version 1.0.0 is here, and it includes an entirely new way to use the PureJS MouseTip script!
-- The script is now wrapped in a MouseTip constructor function instead of a self-executing function
-- The script can now take global style/position overrides when an instance of the constructor is created
-- The script will not find the MouseTip elements or bind mouse events until a constructor instance's .run() function is called
+Read about previous version changes in the [changelog](changelog.md)
 
 ## Installation
 Simply include the `mousetip.js` or `mousetip.min.js` script at the bottom of your document. Than initialize it by creating a new MouseTip instance, and calling .run() on it. That's it!
@@ -48,6 +38,7 @@ Attribute | Description | Default | Example
 `moutstip-css-borderradius` | Alters the CSS border-radius of the tooltip | `4px` | `<div mousetip mousetip-msg="Message" mousetip-css-borderradius="15px"></div>`
 `mousetip-css-background` | Alters the CSS background color of the tooltip | `rgba(0,0,0,0.75)` | `<div mousetip mousetip-msg="Message" mousetip-css-background="white"></div>`
 `mousetip-css-color` | Alters the CSS text color of the tooltip | `#fff` | `<div mousetip mousetip-msg="Message" mousetip-css-color="black"></div>`
+`mousetip-enable-html` or `mousetip-disable-html` | Enables/disables the use of valid HTML within the tooltip message. | `false` | `<div mousetip mousetip-msg="<strong>Message</strong>" mousetip-enable-html></div>`
 
 These inline/attribute adjustments will supersede default and user-set global settings.
 
@@ -62,6 +53,7 @@ In addition to the per-element adjustments above, you can also set global adjust
         cssBorderRadius: '15px', // Default: '4px'
         cssBackground: 'white', // Default: 'rgba(0,0,0,0.75)'
         cssColor: 'black', // Default: '#fff'
+        html: true, // Default: false
         position: 'top left', // Default: 'bottom right'
         selector: 'awesomeName' // Default: 'mousetip'
     });

--- a/src/modules/bind-mouse-enter.js
+++ b/src/modules/bind-mouse-enter.js
@@ -6,6 +6,8 @@ this.bindMouseEnter = function(element, settings) {
         var mouseTip = document.createElement('span'),
             elMsg = element.getAttribute(settings.selector + '-msg'),
             mouseTipMsg = document.createTextNode(elMsg),
+            // ... toggle which HTML attribute to look for based on the global settings, ...
+            mouseTipHTML = settings.html ? element.hasAttribute(settings.selector + '-disable-html') : element.hasAttribute(settings.selector + '-enable-html'),
             // ... attempt to grab any styling attributes, ...
             mouseTipZIndex = element.getAttribute(settings.selector + '-css-zindex'),
             mouseTipPosition = element.getAttribute(settings.selector + '-css-position'),
@@ -22,8 +24,14 @@ this.bindMouseEnter = function(element, settings) {
         mouseTip.style.borderRadius = mouseTipBorderRadius || settings.cssBorderRadius;
         mouseTip.style.background = mouseTipBackground || settings.cssBackground;
         mouseTip.style.color = mouseTipColor || settings.cssColor;
-        // ... append the message to the mouse-tip, ...
-        mouseTip.appendChild(mouseTipMsg);
+        // ... if HTML is disabled globally and not enabled via attribute, or enabled globally and disabled via attribute...
+        if ((!settings.html && !mouseTipHTML) || (settings.html && mouseTipHTML)) {
+            // ... append the message to the mouse-tip as a text-node...
+            mouseTip.appendChild(mouseTipMsg);
+        } else {
+            // ... otherwise, append the message to the mouse-tip as HTML...
+            mouseTip.innerHTML = elMsg;
+        }
         // ... and append the mouse-tip to the document body
         document.body.appendChild(mouseTip);
     });

--- a/src/mousetip.js
+++ b/src/mousetip.js
@@ -1,5 +1,5 @@
 function MouseTip(userSettings) {
-    // Select all elements with the attribute 'mouse-tip', and accept user-defined render settings or constructor defaults
+    // Select all elements with the attribute 'mousetip' (or user-specified selector), and accept user-defined render settings or constructor defaults
     var userSettings = userSettings || {},
         settings = {
             cssZIndex: userSettings.cssZIndex || '9999',
@@ -8,6 +8,7 @@ function MouseTip(userSettings) {
             cssBorderRadius: userSettings.cssPosition || '4px',
             cssBackground: userSettings.cssBackground || 'rgba(0,0,0,0.75)',
             cssColor: userSettings.cssColor || '#fff',
+            html: userSettings.html || false,
             position: userSettings.position || 'bottom right',
             selector: userSettings.selector || 'mousetip'
         },


### PR DESCRIPTION
Added HTML capabilities within MouseTip messages!
- By default, MouseTip runs with HTML capabilities turned off.
- HTML capabilities can be enabled globally via `html: true` in the global settings object
- HTML capabilities can be enabled/disabled individually via the `mousetip-enable-html` or `mousetip-disable-html` attribute