### PR TITLE
Release 2.0.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+### [Version 2.0.1 - Bug Fixes & Optimizations](https://github.com/joeleisner/purejs-mousetip/releases/tag/v2.0.0)
+This version is a minor update to fix/optimize a few things:
+* Fixed a bug that would break mousetip positions set in element attributes when hovering over a child element of the target.
+* Changed the constructor's mousetip state to store a DOM reference to the mousetip itself, removing two `document.getElementById(this.selector)` calls.
+
 ### [Version 2.0.0 - ES2015 Rebuild & New Features](https://github.com/joeleisner/purejs-mousetip/releases/tag/v2.0.0)
 Version 2.0.0 was rebuilt from the ground up to add new features. Here's some of the changes:
 * The main MouseTip constructor function is now an ES2015 class, making for easier code management and shifting towards more modern JS engines. While the default scripts (`mousetip.js` and `mousetip.min.js`) are still compatible with older browsers (transpiled using Babel.js), the ES2015 versions (`mousetip.es2015.js` and `mousetip.es2015.min.js`) will become the default in a later release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "purejs-mousetip",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purejs-mousetip",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A pure javascript solution for creating tooltips that follow your mouse",
   "main": "gulpfile.js",
   "repository": {

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,11 @@ A pure javascript solution for creating tooltips that follow your mouse. This pr
 
 ## Latest Release
 
+### [Version 2.0.1 - Bug Fixes & Optimizations](https://github.com/joeleisner/purejs-mousetip/releases/tag/v2.0.0)
+This version is a minor update to fix/optimize a few things:
+* Fixed a bug that would break mousetip positions set in element attributes when hovering over a child element of the target.
+* Changed the constructor's mousetip state to store a DOM reference to the mousetip itself, removing two `document.getElementById(this.selector)` calls.
+
 ### [Version 2.0.0 - ES2015 Rebuild & New Features](https://github.com/joeleisner/purejs-mousetip/releases/tag/v2.0.0)
 Version 2.0.0 was rebuilt from the ground up to add new features. Here's some of the changes:
 * The main MouseTip constructor function is now an ES2015 class, making for easier code management and shifting towards more modern JS engines. While the default scripts (`mousetip.js` and `mousetip.min.js`) are still compatible with older browsers (using Babel.js), the ES2015 versions (`mousetip.es2015.js` and `mousetip.es2015.min.js`) will become the default in a later release.

--- a/src/mousetip.js
+++ b/src/mousetip.js
@@ -30,21 +30,21 @@ class MouseTip {
             this.cssBackground   = cssBackground;
             this.cssColor        = cssColor;
         }
-        // Store the state of the mousetip
-        this.mouseTip = false;
     }
 
     // Create the mousetip
     createMouseTip(event) {
+        // Store the target element
+        this.element = event.target;
         // Create the mousetip
         const mouseTip = document.createElement('span');
         // Store the styling either from the target element's attributes or the constructor settings
-        const zIndex       = event.target.getAttribute(this.selector + '-css-zindex')       || this.cssZIndex;
-        const position     = event.target.getAttribute(this.selector + '-css-position')     || this.cssPosition;
-        const padding      = event.target.getAttribute(this.selector + '-css-padding')      || this.cssPadding;
-        const borderRadius = event.target.getAttribute(this.selector + '-css-borderradius') || this.cssBorderRadius;
-        const background   = event.target.getAttribute(this.selector + '-css-background')   || this.cssBackground;
-        const color        = event.target.getAttribute(this.selector + '-css-color')        || this.cssColor;
+        const zIndex       = this.element.getAttribute(this.selector + '-css-zindex')       || this.cssZIndex;
+        const position     = this.element.getAttribute(this.selector + '-css-position')     || this.cssPosition;
+        const padding      = this.element.getAttribute(this.selector + '-css-padding')      || this.cssPadding;
+        const borderRadius = this.element.getAttribute(this.selector + '-css-borderradius') || this.cssBorderRadius;
+        const background   = this.element.getAttribute(this.selector + '-css-background')   || this.cssBackground;
+        const color        = this.element.getAttribute(this.selector + '-css-color')        || this.cssColor;
         // Assign the ID and styling to the mousetip
         mouseTip.id                 = this.selector;
         mouseTip.style.zIndex       = zIndex;
@@ -54,10 +54,10 @@ class MouseTip {
         mouseTip.style.background   = background;
         mouseTip.style.color        = color;
         // Grab the message and HTML attributes from the event target
-        const message  = event.target.getAttribute(this.selector + '-msg');
+        const message  = this.element.getAttribute(this.selector + '-msg');
         const html     = this.html ?
-            event.target.hasAttribute(this.selector + '-disable-html') :
-            event.target.hasAttribute(this.selector + '-enable-html');
+            this.element.hasAttribute(this.selector + '-disable-html') :
+            this.element.hasAttribute(this.selector + '-enable-html');
         // If HTML is disabled globally and on the target element (or the inverse)...
         if ((!this.html && !html) || (this.html && html)) {
             // ... append the message to the mousetip as a text-node...
@@ -68,43 +68,43 @@ class MouseTip {
         }
         // Append the mousetip to the bottom of the page...
         document.body.appendChild(mouseTip);
-        // ... and update the constructor's mousetip state
-        this.mouseTip = true;
+        // ... and store the mousetip
+        this.mouseTip = document.getElementById(this.selector);
     }
 
     // Delete the mousetip
     deleteMouseTip() {
-        // If the constructor's mousetip state is not true, return
+        // If the stored mousetip does not exist, return
         if (!this.mouseTip) return;
-        // Grab the mousetip,...
-        const mouseTip = document.getElementById(this.selector);
-        // ... delete it,...
-        mouseTip.parentNode.removeChild(mouseTip);
-        // ... and update the constructor's mousetip state
-        this.mouseTip = false;
+        // Delete the mousetip...
+        this.mouseTip.parentNode.removeChild(this.mouseTip);
+        // ... and delete the stored mousetip
+        delete this.mouseTip;
+        // If the stored target element does not exist, return
+        if (!this.element) return;
+        // Delete the stored target element
+        delete this.element;
     }
 
     // Update the mousetip
     updateMouseTip(event) {
-        // Grab the mousetip
-        const mouseTip = document.getElementById(this.selector);
         // Grab the X/Y of the mouse
         const mouseX = event.pageX;
         const mouseY = event.pageY;
         // Set the default adjustment to 15
         const defaultAdjust = 15;
         // Get the mousetip position from the target element or the constructor
-        let position = (event.target.getAttribute(this.selector + '-pos') || this.position).split(' '),
+        let position = (this.element.getAttribute(this.selector + '-pos') || this.position).split(' '),
             verticalAdjust, horizontalAdjust;
         // If the position does not contain two items, set it to the default
         if (position.length !== 2) position = ['bottom', 'right'];
         // Set the vertical adjustment from the first item of position
         switch(position[0]) {
         case 'top':
-            verticalAdjust = -defaultAdjust - mouseTip.offsetHeight;
+            verticalAdjust = -defaultAdjust - this.mouseTip.offsetHeight;
             break;
         case 'center':
-            verticalAdjust = 0 - (mouseTip.offsetHeight / 2);
+            verticalAdjust = 0 - (this.mouseTip.offsetHeight / 2);
             break;
         default:
             verticalAdjust = defaultAdjust;
@@ -112,17 +112,17 @@ class MouseTip {
         // Set the horizontal adjustment from the second item of position
         switch(position[1]) {
         case 'left':
-            horizontalAdjust = -defaultAdjust - mouseTip.offsetWidth;
+            horizontalAdjust = -defaultAdjust - this.mouseTip.offsetWidth;
             break;
         case 'center':
-            horizontalAdjust = 0 - (mouseTip.offsetWidth / 2);
+            horizontalAdjust = 0 - (this.mouseTip.offsetWidth / 2);
             break;
         default:
             horizontalAdjust = defaultAdjust;
         }
         // Update the mousetip's position
-        mouseTip.style.top  = `${ mouseY + verticalAdjust }px`;
-        mouseTip.style.left = `${ mouseX + horizontalAdjust }px`;
+        this.mouseTip.style.top  = `${ mouseY + verticalAdjust }px`;
+        this.mouseTip.style.left = `${ mouseX + horizontalAdjust }px`;
     }
 
     // Handle mouse events


### PR DESCRIPTION
This version is a minor update to fix/optimize a few things:
* Fixed a bug that would break mousetip positions set in element attributes when hovering over a child element of the target.
* Changed the constructor's mousetip state to store a DOM reference to the mousetip itself, removing two `document.getElementById(this.selector)` calls.