### PR TITLE
2.1.2 - Gulp Watch Fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,22 +1,26 @@
 # Change Log
 
-### [Version 2.1.1 - Security Vulnerability Fixes](https://github.com/joeleisner/purejs-mousetip/releases/tag/v2.1.1)
+## [Version 2.1.2 - Gulp Watch Fix](https://github.com/joeleisner/purejs-mousetip/releases/tag/v2.1.2)
+Another minor update in the same day? Yeah, I made a mistake; Here's what I fixed:
+* The build-system's `gulp watch` task is now working
+
+## [Version 2.1.1 - Security Vulnerability Fixes](https://github.com/joeleisner/purejs-mousetip/releases/tag/v2.1.1)
 This minor update includes some fixes related to security vulnerabilities! Here's the details:
 * Gulp was updated to 4.0 to fix security vulnerabilities
 * The build-system was restructured to work with the new version of Gulp
 
-### [Version 2.1.0 - CommonJS & ES2015 Modules](https://github.com/joeleisner/purejs-mousetip/releases/tag/v2.1.0)
+## [Version 2.1.0 - CommonJS & ES2015 Modules](https://github.com/joeleisner/purejs-mousetip/releases/tag/v2.1.0)
 This version now includes CommonJS & ES2015 modules to more easily include Pure JS MouseTip into your projects! Here's the details:
 * Modules can be found in the `dist/modules` directory
 * The CommonJS module exports the class as: `module.exports = MouseTip;`
 * The ES2015 module exports the class as: `export default MouseTip;`
 
-### [Version 2.0.1 - Bug Fixes & Optimizations](https://github.com/joeleisner/purejs-mousetip/releases/tag/v2.0.1)
+## [Version 2.0.1 - Bug Fixes & Optimizations](https://github.com/joeleisner/purejs-mousetip/releases/tag/v2.0.1)
 This version is a minor update to fix/optimize a few things:
 * Fixed a bug that would break mousetip positions set in element attributes when hovering over a child element of the target.
 * Changed the constructor's mousetip state to store a DOM reference to the mousetip itself, removing two `document.getElementById(this.selector)` calls.
 
-### [Version 2.0.0 - ES2015 Rebuild & New Features](https://github.com/joeleisner/purejs-mousetip/releases/tag/v2.0.0)
+## [Version 2.0.0 - ES2015 Rebuild & New Features](https://github.com/joeleisner/purejs-mousetip/releases/tag/v2.0.0)
 Version 2.0.0 was rebuilt from the ground up to add new features. Here's some of the changes:
 * The main MouseTip constructor function is now an ES2015 class, making for easier code management and shifting towards more modern JS engines. While the default scripts (`mousetip.js` and `mousetip.min.js`) are still compatible with older browsers (transpiled using Babel.js), the ES2015 versions (`mousetip.es2015.js` and `mousetip.es2015.min.js`) will become the default in a later release.
 * A bug was fixed where certain user-set CSS settings were not mapped properly to the constructor's settings.
@@ -25,15 +29,15 @@ Version 2.0.0 was rebuilt from the ground up to add new features. Here's some of
 * A new `stylesheet` constructor setting was added (false by default). This allows you to specify not to include inline styles on the mousetip element, and instead expect the styling to be included in a stylesheet on the page. Element attributes will still work in this mode.
 * The build system has been reworked, include upgraded/new dependencies and a change of structure. The most noticeable change is that the default scripts are now built with Babel.js; While this leads to larger file sizes, it allows for future-proofing our script and ensures more browser support with less testing.
 
-### [Version 1.2.3 - NPM Publish Issues](https://github.com/joeleisner/purejs-mousetip/releases/tag/v1.2.3)
+## [Version 1.2.3 - NPM Publish Issues](https://github.com/joeleisner/purejs-mousetip/releases/tag/v1.2.3)
 This release is exactly the same as 1.2.2, except with the version number incremented up by one. Unfortunately, I had mistakenly published a version 1.2.2 a while back and cannot overwrite this unpublished version. Instead of letting release versions get out of sync between the repo and the NPM package, I'm pushing this change to set things straight again.
 
-### [Version 1.2.2 - Build System Improvements](https://github.com/joeleisner/purejs-mousetip/releases/tag/v1.2.2)
+## [Version 1.2.2 - Build System Improvements](https://github.com/joeleisner/purejs-mousetip/releases/tag/v1.2.2)
 This update includes some build-system improvements:
 * All build-system javascript now utilizes ES2015 (ES6) syntax
 * Removed the `clean` task from Gulp
 
-### [Version 1.2.1 - Bug Fixes & Optimizations](https://github.com/joeleisner/purejs-mousetip/releases/tag/v1.2.1)
+## [Version 1.2.1 - Bug Fixes & Optimizations](https://github.com/joeleisner/purejs-mousetip/releases/tag/v1.2.1)
 Minor updates have been made. Here's what's changed:
 * MouseTip can now be installed by NPM! (Check out the Installation section)
 * By default, MouseTip now runs with HTML capabilities turned on
@@ -41,7 +45,7 @@ Minor updates have been made. Here's what's changed:
 * Linting warnings squashed
 * Build system optimized
 
-### [Version 1.2.0 - HTML Messages](https://github.com/joeleisner/purejs-mousetip/releases/tag/v1.2.0)
+## [Version 1.2.0 - HTML Messages](https://github.com/joeleisner/purejs-mousetip/releases/tag/v1.2.0)
 Added HTML capabilities within MouseTip messages!
 * By default, MouseTip runs with HTML capabilities turned off
 * HTML capabilities can be enabled globally via `html: true` in the global settings object

--- a/gulp/tasks.js
+++ b/gulp/tasks.js
@@ -45,6 +45,6 @@ module.exports = {
     },
     watch() {
         const { all } = this;
-        gulp.watch(config.watch, all());
+        return () => gulp.watch(config.watch, all.bind(this)());
     }
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,5 +7,5 @@ gulp.task('build',                            tasks.all());
 gulp.task('build-commonjs-module', tasks.modules.commonJs);
 gulp.task('build-es2015-module',     tasks.modules.es2015);
 gulp.task('build-modules',            tasks.modules.all());
-gulp.task('default',                          tasks.watch);
-gulp.task('watch',                            tasks.watch);
+gulp.task('default',                        tasks.watch());
+gulp.task('watch',                          tasks.watch());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "purejs-mousetip",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purejs-mousetip",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A pure javascript solution for creating tooltips that follow your mouse",
   "main": "gulpfile.js",
   "repository": {

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,10 @@ A pure javascript solution for creating tooltips that follow your mouse. This pr
 
 ## Latest Release
 
+### [Version 2.1.2 - Gulp Watch Fix](https://github.com/joeleisner/purejs-mousetip/releases/tag/v2.1.2)
+Another minor update in the same day? Yeah, I made a mistake; Here's what I fixed:
+* The build-system's `gulp watch` task is now working
+
 ### [Version 2.1.1 - Security Vulnerability Fixes](https://github.com/joeleisner/purejs-mousetip/releases/tag/v2.1.1)
 This minor update includes some fixes related to security vulnerabilities! Here's the details:
 * Gulp was updated to 4.0 to fix security vulnerabilities


### PR DESCRIPTION
* Updated the package.json version to 2.1.2
* Fixed an issue where the watch task did not work due to this binding issues when piped through gulp
* Updated the readme.md and changelog.md to contain information about the 2.1.2 update