### PR TITLE
Unique identifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,9 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.12.8",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.8.tgz",
-      "integrity": "sha512-ra28JXL+5z73r1IC/t+FT1ApXU5LsulFDnTDntNfLQaScJUJmcHL5Qxm/IWanCToQk3bPWQo5bflbplU5r15pg==",
+      "version": "7.12.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz",
+      "integrity": "sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -31,7 +31,7 @@
         "@babel/helpers": "^7.12.5",
         "@babel/parser": "^7.12.7",
         "@babel/template": "^7.12.7",
-        "@babel/traverse": "^7.12.8",
+        "@babel/traverse": "^7.12.9",
         "@babel/types": "^7.12.7",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
@@ -41,6 +41,25 @@
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "@babel/traverse": {
+          "version": "7.12.9",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.9.tgz",
+          "integrity": "sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.12.5",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.11.0",
+            "@babel/parser": "^7.12.7",
+            "@babel/types": "^7.12.7",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          }
+        }
       }
     },
     "@babel/generator": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@babel/core": "^7.12.8",
+    "@babel/core": "^7.12.9",
     "@babel/preset-env": "^7.12.7",
     "autoprefixer": "^9.8.6",
     "babel-loader": "^8.2.1",

--- a/src/mousetip.js
+++ b/src/mousetip.js
@@ -4,6 +4,7 @@ import animationsCSS from './animations.css';
 export default class MouseTip {
     // Construct the class
     constructor({
+        id         = null,
         animations = true,
         direction  = [ 'bottom', 'right' ],
         html       = true,
@@ -25,6 +26,9 @@ export default class MouseTip {
             reducedMotion: false,
             stop:          false
         };
+
+        // Initialize a unique identifier
+        this.id = id;
 
         // Define the global animations...
         this.animations = animations;
@@ -52,7 +56,6 @@ export default class MouseTip {
         if (this.animations && typeof this.animations !== 'object') this.animations = {};
         // ... and use the appropriate global CSS depending on if animations are enabled or not
         this.css = this.animations ? animationsCSS : stylesCSS;
-        console.log(this.css)
     }
 
     // Override default objects with that of user defined objects
@@ -110,7 +113,7 @@ export default class MouseTip {
         // Create an overrides style tag...
         const overrides = document.createElement('style');
         // ... and with a rule giving the class name the generated CSS variables
-        overrides.textContent = `[class="${ mousetip }"]{${ variables.join('')}}`;
+        overrides.textContent = `#${this.id}{${ variables.join('')}}`;
 
         // Finally, initialize the global CSS,...
         this.css.use();
@@ -285,7 +288,9 @@ export default class MouseTip {
 
         // Create the mousetip,...
         this.mouseTip.element = document.createElement('span');
-        // ... assign its class name,...
+        // ... assign its ID...
+        this.mouseTip.element.id = this.id;
+        // ... and its class name,...
         this.mouseTip.element.className = this.stylesheet ? this.selector.full : this.css.locals.mousetip;
         // ... set its styles,...
         this.setLocalStyles();
@@ -494,6 +499,11 @@ export default class MouseTip {
         if (this.state.stop) this.targets = [];
     }
 
+    // Generate a unique ID
+    uniqueId() {
+        return '_' + Math.random().toString(36).substr(2, 9);
+    }
+
     // Start handling mouse events
     start(elements) {
         // Grab all target elements by selector...
@@ -501,8 +511,10 @@ export default class MouseTip {
         // ... and if no target elements were found, do nothing
         if (!targets) return;
 
-        // Store the target elements for reference
+        // Store the target elements for reference...
         this.targets = targets;
+        // ... and give this instance's mousetips a unique ID
+        if (!this.id) this.id = this.uniqueId();
 
         // Add the reduced motion...
         this.reducedMotion();
@@ -520,6 +532,8 @@ export default class MouseTip {
 
         // Enable the stop state,...
         this.state.stop = true;
+        // ... and reset the unique ID
+        this.id = null;
 
         // Remove the reduced motion...
         this.reducedMotion();


### PR DESCRIPTION
When initializing multiple instances of MouseTip, it includes the styles only once; This creates a problem for global style/animation overrides, as the existing code creates these overrides for the class, which is shared between all instances, causing the overrides to affect all instances. To combat this, a unique identifier is now generated and the overrides target this ID instead of the class. This ID can also be manually set within the constructor object.